### PR TITLE
"Titles" refactor

### DIFF
--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -11,6 +11,8 @@ except ImportError:  # pragma: no cover
 from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2, urlunparse, is_py3
 from streamlink.exceptions import PluginError
 from streamlink.utils.named_pipe import NamedPipe
+from streamlink.utils.lazy_formatter import LazyFormatter
+from streamlink.utils.encoding import get_filesystem_encoding, maybe_decode, maybe_encode
 
 
 def swfdecompress(data):
@@ -348,4 +350,5 @@ def escape_librtmp(value):
 __all__ = ["urlopen", "urlget", "urlresolve", "swfdecompress", "swfverify",
            "verifyjson", "absolute_url", "parse_qsd", "parse_json", "res_json",
            "parse_xml", "res_xml", "rtmpparse", "prepend_www", "NamedPipe",
-           "escape_librtmp"]
+           "escape_librtmp", "LazyFormatter", "get_filesystem_encoding",
+           "maybe_decode", "maybe_encode"]

--- a/src/streamlink/utils/encoding.py
+++ b/src/streamlink/utils/encoding.py
@@ -1,0 +1,30 @@
+from sys import getfilesystemencoding
+
+from streamlink.compat import is_win32, is_py2
+
+
+def get_filesystem_encoding():
+    file_system_encoding = getfilesystemencoding()
+    if file_system_encoding is None:  # `None` not possible after python 3.2
+        if is_win32:
+            file_system_encoding = 'mbcs'
+        else:
+            file_system_encoding = 'utf-8'
+    return file_system_encoding
+
+
+def maybe_encode(text, encoding="utf8"):
+    if is_py2:
+        return text.encode(encoding)
+    else:
+        return text
+
+
+def maybe_decode(text, encoding="utf8"):
+    if is_py2 and isinstance(text, str):
+        return text.decode(encoding)
+    else:
+        return text
+
+
+__all__ = ["get_filesystem_encoding", "maybe_decode", "maybe_encode"]

--- a/src/streamlink/utils/lazy_formatter.py
+++ b/src/streamlink/utils/lazy_formatter.py
@@ -1,5 +1,6 @@
 import string
 
+
 class LazyFormatter(object):
     def __init__(self, **lazy_props):
         self.lazy_props = lazy_props

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -156,6 +156,7 @@ def hours_minutes_seconds(value):
 
     return s
 
+
 def build_parser():
     parser = ArgumentParser(
         prog="streamlink",
@@ -509,28 +510,30 @@ def build_parser():
         This option is only supported for the following players: {0}.
 
         {{title}}
-          If available, this is the title of the stream.
-          Otherwise, it is the string "{1}"
+            If available, this is the title of the stream.
+            Otherwise, it is the string "{1}"
 
         {{author}}
-          If available, this is the author of the stream.
-          Otherwise, it is the string "{2}"
+            If available, this is the author of the stream.
+            Otherwise, it is the string "{2}"
 
         {{category}}
-          If available, this is the category the stream has been placed into.
-              For twitch, this is the game being played
-              For youtube, it's the category e.g. Gaming, Sports, Music...
-          Otherwise, it is the string "{3}"
+            If available, this is the category the stream has been placed into.
+            
+            - For twitch, this is the game being played
+            - For youtube, it's the category e.g. Gaming, Sports, Music...
+            
+            Otherwise, it is the string "{3}"
 
         {{game}}
-          This is just a synonym for {{category}} which may make more sense for
-          gaming oriented platforms. "Game being played" is a way to categorize
-          the stream, so it doesn't need its own seperate handling.
-
-        """.format( ', '.join(SUPPORTED_PLAYERS.keys()),
-                    DEFAULT_STREAM_METADATA['title'],
-                    DEFAULT_STREAM_METADATA['author'],
-                    DEFAULT_STREAM_METADATA['category'])
+            This is just a synonym for {{category}} which may make more sense for
+            gaming oriented platforms. "Game being played" is a way to categorize
+            the stream, so it doesn't need its own separate handling.
+            
+        """.format(', '.join(SUPPORTED_PLAYERS.keys()),
+                   DEFAULT_STREAM_METADATA['title'],
+                   DEFAULT_STREAM_METADATA['author'],
+                   DEFAULT_STREAM_METADATA['category'])
     )
 
     output = parser.add_argument_group("File output options")

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -29,10 +29,10 @@ def shlex_quote(s):
 
     Backported from Python 3.3 standard library module shlex.
     """
-    
-    if is_py3: #use the latest version instead of backporting if it's available
+
+    if is_py3:  # use the latest version instead of backporting if it's available
         return quote(s)
-        
+
     if not s:
         return "''"
     if _find_unsafe(s) is None:
@@ -41,19 +41,7 @@ def shlex_quote(s):
     # use single quotes, and put single quotes into double quotes
     # the string $'b is then quoted as '$'"'"'b'
     return "'" + s.replace("'", "'\"'\"'") + "'"
-        
-def maybe_encode(text, encoding="utf8"):
-    if is_py2:
-        return text.encode(encoding)
-    else:
-        return text
-
-def maybe_decode(text, encoding="utf8"):
-    if is_py2 and isinstance(text, str):
-        return text.decode(encoding)
-    else:
-        return text
 
 
 __all__ = ["is_py2", "is_py3", "is_win32", "input", "stdout", "file",
-           "shlex_quote", "get_terminal_size", "maybe_encode", "maybe_decode"]
+           "shlex_quote", "get_terminal_size"]

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -1,9 +1,7 @@
 import os
 
 from streamlink import __version__ as LIVESTREAMER_VERSION
-
 from .compat import is_win32
-from .utils import find_default_player
 
 DEFAULT_PLAYER_ARGUMENTS = u"{filename}"
 DEFAULT_STREAM_METADATA = {
@@ -12,10 +10,10 @@ DEFAULT_STREAM_METADATA = {
     "category": u"No Category",
     "game": u"No Game/Category"
 }
-SUPPORTED_PLAYERS = {  #these are the players that streamlink knows how to set the window title for with `--title`. key names are used in help text
-    #name      #possible binary names
-    "vlc"    : ["vlc",find_default_player()],
-    "mpv"    : ["mpv"]
+SUPPORTED_PLAYERS = {  # these are the players that streamlink knows how to set the window title for with `--title`. key names are used in help text
+    # name: possible binary names (linux/mac and windows)
+    "vlc": ["vlc", "vlc.exe"],
+    "mpv": ["mpv", "mpv.exe"]
 }
 
 if is_win32:

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -7,10 +7,10 @@ from .utils import find_default_player
 
 DEFAULT_PLAYER_ARGUMENTS = u"{filename}"
 DEFAULT_STREAM_METADATA = {
-    "title"    : u"Unknown Title",
-    "author"   : u"Unknown Author",
-    "category" : u"No Category",
-    "game"     : u"No Game/Category"
+    "title": u"Unknown Title",
+    "author": u"Unknown Author",
+    "category": u"No Category",
+    "game": u"No Game/Category"
 }
 SUPPORTED_PLAYERS = {  #these are the players that streamlink knows how to set the window title for with `--title`. key names are used in help text
     #name      #possible binary names

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -26,14 +26,16 @@ from streamlink.exceptions import FatalPluginError
 from streamlink.stream import StreamProcess
 from streamlink.plugins.twitch import TWITCH_CLIENT_ID
 from streamlink.plugin import PluginOptions
+from streamlink.utils import LazyFormatter
 
 import streamlink.logger as logger
 from .argparser import build_parser
-from .compat import stdout, is_win32, is_py2, is_py3, maybe_encode
+from .compat import stdout, is_win32, is_py2, is_py3
+from streamlink.utils.encoding import maybe_encode
 from .console import ConsoleOutput, ConsoleUserInputRequester
 from .constants import CONFIG_FILES, PLUGINS_DIR, STREAM_SYNONYMS, DEFAULT_STREAM_METADATA
 from .output import FileOutput, PlayerOutput
-from .utils import NamedPipe, HTTPServer, ignored, progress, stream_to_url, LazyFormatter
+from .utils import NamedPipe, HTTPServer, ignored, progress, stream_to_url
 
 ACCEPTABLE_ERRNO = (errno.EPIPE, errno.EINVAL, errno.ECONNRESET)
 try:
@@ -138,7 +140,7 @@ def create_title(plugin=None):
     else:
         title = args.url
     return title
-    
+
 def iter_http_requests(server, player):
     """Repeatedly accept HTTP connections on a server.
 

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -2,15 +2,12 @@ import os
 import shlex
 import subprocess
 import sys
-
 from time import sleep
 
-import re
-
-from .compat import is_win32, is_py2, stdout, shlex_quote
-from .constants import DEFAULT_PLAYER_ARGUMENTS, DEFAULT_STREAM_METADATA, SUPPORTED_PLAYERS
-from .utils import ignored
 from streamlink.utils.encoding import get_filesystem_encoding, maybe_encode, maybe_decode
+from .compat import is_win32, stdout
+from .constants import DEFAULT_PLAYER_ARGUMENTS, SUPPORTED_PLAYERS
+from .utils import ignored
 
 if is_win32:
     import msvcrt
@@ -110,10 +107,15 @@ class PlayerOutput(Output):
         :param cmd: command to test
         :return: name of the player|None
         """
-        cmd = cmd.lower()
+        if not is_win32:
+            # under a POSIX system use shlex to find the actual command
+            # under windows this is not an issue because executables end in .exe
+            cmd = shlex.split(cmd)[0]
+
+        cmd = os.path.basename(cmd.lower())
         for player, possiblecmds in SUPPORTED_PLAYERS.items():
             for possiblecmd in possiblecmds:
-                if possiblecmd in cmd:
+                if cmd.startswith(possiblecmd):
                     return player
 
     def _create_arguments(self):

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -67,7 +67,7 @@ class FileOutput(Output):
 class PlayerOutput(Output):
     PLAYER_TERMINATE_TIMEOUT = 10.0
 
-    def __init__(self, cmd, args=DEFAULT_PLAYER_ARGUMENTS, filename=None, quiet=True, kill=True, call=False, http=False,
+    def __init__(self, cmd, args=DEFAULT_PLAYER_ARGUMENTS, filename=None, quiet=True, kill=True, call=False, http=None,
                  namedpipe=None, title=None):
         super(PlayerOutput, self).__init__()
         self.cmd = cmd

--- a/src/streamlink_cli/utils/__init__.py
+++ b/src/streamlink_cli/utils/__init__.py
@@ -1,18 +1,14 @@
 import json
-from sys import getfilesystemencoding
-
 from contextlib import contextmanager
 
-from .http_server import HTTPServer
 from streamlink.utils.named_pipe import NamedPipe
-from .progress import progress
-from .player import find_default_player
-from .stream import stream_to_url
-from .lazy_formatter import *
-
+from streamlink_cli.utils.http_server import HTTPServer
+from streamlink_cli.utils.player import find_default_player
+from streamlink_cli.utils.progress import progress
+from streamlink_cli.utils.stream import stream_to_url
 
 __all__ = [
-    "NamedPipe", "HTTPServer", "JSONEncoder", "LazyFormatter",
+    "NamedPipe", "HTTPServer", "JSONEncoder",
     "find_default_player", "ignored", "progress", "stream_to_url"
 ]
 
@@ -35,11 +31,3 @@ def ignored(*exceptions):
         pass
 
 
-def get_filesystem_encoding():
-    fileSystemEncoding = getfilesystemencoding()
-    if fileSystemEncoding is None: #`None` not possible after python 3.2
-        if is_win32:
-            fileSystemEncoding = 'mbcs'
-        else:
-            fileSystemEncoding = 'utf-8'
-    return fileSystemEncoding

--- a/tests/plugins/testplugin.py
+++ b/tests/plugins/testplugin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 from io import BytesIO
 
 from streamlink import NoStreamsError
@@ -23,6 +24,15 @@ class TestPlugin(Plugin):
     @classmethod
     def can_handle_url(self, url):
         return "test.se" in url
+
+    def get_title(self):
+        return "Test Title"
+
+    def get_author(self):
+        return u"Tѥst Āuƭhǿr"
+
+    def get_category(self):
+        return None
 
     def _get_streams(self):
         if "empty" in self.url:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,17 +1,11 @@
-import sys
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
-
+# -*- coding: utf8 -*-
 import os.path
+import unittest
+
 import streamlink_cli.main
-try:
-    from unittest.mock import patch, ANY
-except ImportError:
-    from mock import patch, ANY
 from streamlink import Streamlink
 from streamlink_cli.compat import is_win32
+from tests.mock import patch, ANY
 
 PluginPath = os.path.join(os.path.dirname(__file__), "plugins")
 
@@ -22,7 +16,7 @@ def setup_streamlink():
     return streamlink_cli.main.streamlink
 
 
-class TestCommandLineInvocation(unittest.TestCase):
+class CommandLineTestCase(unittest.TestCase):
     """
     Test that when invoked for the command line arguments are parsed as expected
     """
@@ -38,6 +32,7 @@ class TestCommandLineInvocation(unittest.TestCase):
             def fn(*args):
                 result = results.pop(0)
                 return result
+
             return fn
 
         mock_popen().poll.side_effect = side_effect([None, 0])
@@ -55,72 +50,69 @@ class TestCommandLineInvocation(unittest.TestCase):
         else:
             mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY)
 
-    #
-    # POSIX tests
-    #
 
-    @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+class TestCommandLinePOSIX(CommandLineTestCase):
+    """
+    Commandline tests under POSIX-like operating systems
+    """
+
     def test_open_regular_path_player(self):
-        self._test_args(["streamlink", "-p", "/usr/bin/vlc", "http://test.se", "test"],
-                        ["/usr/bin/vlc", "-"])
+        self._test_args(["streamlink", "-p", "/usr/bin/player", "http://test.se", "test"],
+                        ["/usr/bin/player", "-"])
 
-    @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
     def test_open_space_path_player(self):
-        self._test_args(["streamlink", "-p", "\"/Applications/Video Player/VLC/vlc\"", "http://test.se", "test"],
-                        ["/Applications/Video Player/VLC/vlc", "-"])
+        self._test_args(["streamlink", "-p", "\"/Applications/Video Player/player\"", "http://test.se", "test"],
+                        ["/Applications/Video Player/player", "-"])
         # escaped
-        self._test_args(["streamlink", "-p", "/Applications/Video\ Player/VLC/vlc", "http://test.se", "test"],
-                        ["/Applications/Video Player/VLC/vlc", "-"])
+        self._test_args(["streamlink", "-p", "/Applications/Video\ Player/player", "http://test.se", "test"],
+                        ["/Applications/Video Player/player", "-"])
 
-    @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
     def test_open_player_extra_args_in_player(self):
-        self._test_args(["streamlink", "-p", "/usr/bin/vlc",
+        self._test_args(["streamlink", "-p", "/usr/bin/player",
                          "-a", '''--input-title-format "Poker \\"Stars\\"" {filename}''',
                          "http://test.se", "test"],
-                        ["/usr/bin/vlc", "--input-title-format", 'Poker "Stars"', "-"])
+                        ["/usr/bin/player", "--input-title-format", 'Poker "Stars"', "-"])
 
-    @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
     def test_open_player_extra_args_in_player_pass_through(self):
-        self._test_args(["streamlink", "--player-passthrough", "rtmp", "-p", "/usr/bin/vlc",
+        self._test_args(["streamlink", "--player-passthrough", "rtmp", "-p", "/usr/bin/player",
                          "-a", '''--input-title-format "Poker \\"Stars\\"" {filename}''',
                          "test.se", "rtmp"],
-                        ["/usr/bin/vlc", "--input-title-format", 'Poker "Stars"', "rtmp://test.se"],
+                        ["/usr/bin/player", "--input-title-format", 'Poker "Stars"', "rtmp://test.se"],
                         passthrough=True)
 
-    #
-    # Windows Tests
-    #
 
-    @unittest.skipIf(not is_win32, "test only applicable on Windows")
-    def test_open_space_path_player_win32(self):
-        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\VLC\\vlc.exe", "http://test.se", "test"],
-                        "c:\\Program Files\\VideoLAN\\VLC\\vlc.exe -")
+@unittest.skipIf(not is_win32, "test only applicable on Windows")
+class TestCommandLineWindows(CommandLineTestCase):
+    """
+    Commandline tests for Windows
+    """
 
-    @unittest.skipIf(not is_win32, "test only applicable on Windows")
-    def test_open_space_quote_path_player_win32(self):
-        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\VideoLAN\VLC\\vlc.exe\"", "http://test.se", "test"],
-                        "\"c:\\Program Files\\VideoLAN\\VLC\\vlc.exe\" -")
+    def test_open_space_path_player(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\Player\\player.exe", "http://test.se", "test"],
+                        "c:\\Program Files\\Player\\player.exe -")
 
-    @unittest.skipIf(not is_win32, "test only applicable on Windows")
-    def test_open_player_args_with_quote_in_player_win32(self):
+    def test_open_space_quote_path_player(self):
+        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\Player\\player.exe\"", "http://test.se", "test"],
+                        "\"c:\\Program Files\\Player\\player.exe\" -")
+
+    def test_open_player_args_with_quote_in_player(self):
         self._test_args(["streamlink", "-p",
-                         '''c:\\Program Files\\VideoLAN\VLC\\vlc.exe --input-title-format "Poker \\"Stars\\""''',
+                         '''c:\\Program Files\\Player\\player.exe --input-title-format "Poker \\"Stars\\""''',
                          "http://test.se", "test"],
-                        '''c:\\Program Files\\VideoLAN\VLC\\vlc.exe --input-title-format "Poker \\"Stars\\"" -''')
+                        '''c:\\Program Files\\Player\\player.exe --input-title-format "Poker \\"Stars\\"" -''')
 
-    @unittest.skipIf(not is_win32, "test only applicable on Windows")
-    def test_open_player_extra_args_in_player_win32(self):
-        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\VLC\\vlc.exe",
+    def test_open_player_extra_args_in_player(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\Player\\player.exe",
                          "-a", '''--input-title-format "Poker \\"Stars\\"" {filename}''',
                          "http://test.se", "test"],
-                        '''c:\\Program Files\\VideoLAN\VLC\\vlc.exe --input-title-format "Poker \\"Stars\\"" -''')
+                        '''c:\\Program Files\\Player\\player.exe --input-title-format "Poker \\"Stars\\"" -''')
 
-    @unittest.skipIf(not is_win32, "test only applicable on Windows")
-    def test_open_player_extra_args_in_player_pass_through_win32(self):
-        self._test_args(["streamlink", "--player-passthrough", "rtmp", "-p", "c:\\Program Files\\VideoLAN\VLC\\vlc.exe",
+    def test_open_player_extra_args_in_player_pass_through(self):
+        self._test_args(["streamlink", "--player-passthrough", "rtmp", "-p", "c:\\Program Files\\Player\\player.exe",
                          "-a", '''--input-title-format "Poker \\"Stars\\"" {filename}''',
                          "test.se", "rtmp"],
-                        '''c:\\Program Files\\VideoLAN\VLC\\vlc.exe --input-title-format "Poker \\"Stars\\"" \"rtmp://test.se\"''',
+                        '''c:\\Program Files\\Player\\player.exe --input-title-format "Poker \\"Stars\\"" \"rtmp://test.se\"''',
                         passthrough=True)
 
 

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -1,7 +1,8 @@
 # coding=utf8
 import unittest
 
-from streamlink.compat import is_win32
+from streamlink.compat import is_win32, is_py3
+from streamlink.utils import get_filesystem_encoding
 from tests.test_cmdline import CommandLineTestCase
 
 
@@ -30,10 +31,15 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
         self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "--title", "{title}", "http://test.se", "test"],
                         "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"Test Title\" -")
 
-    @unittest.skip("encoding unknown")
-    def test_open_player_with_unicode_author_vlc(self):
+    @unittest.skipIf(is_py3, "Encoding is different in Python 2")
+    def test_open_player_with_unicode_author_vlc_py2(self):
         self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "--title", "{author}", "http://test.se", "test"],
-                        "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"T\xd1\xa5st \xc4\x80u\xc6\xadh\xc7\xbfr\" -")
+                        "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"" + u"Tѥst Āuƭhǿr".encode(get_filesystem_encoding()) + "\" -")
+
+    @unittest.skipIf(not is_py3, "Encoding is different in Python 2")
+    def test_open_player_with_unicode_author_vlc_py3(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "--title", "{author}", "http://test.se", "test"],
+                        u"c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"Tѥst Āuƭhǿr\" -")
 
     def test_open_player_with_default_title_vlc(self):
         self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "http://test.se", "test"],

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -11,11 +11,9 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc", "--title", "{title}", "http://test.se", "test"],
                         ["/usr/bin/vlc", "--input-title-format", 'Test Title', "-"])
 
-
     def test_open_player_with_unicode_author_vlc(self):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc", "--title", "{author}", "http://test.se", "test"],
                         ["/usr/bin/vlc", "--input-title-format", u"Tѥst Āuƭhǿr", "-"])
-
 
     def test_open_player_with_default_title_vlc(self):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc", "http://test.se", "test"],

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -1,0 +1,46 @@
+# coding=utf8
+import unittest
+
+from streamlink.compat import is_win32
+from tests.test_cmdline import CommandLineTestCase
+
+
+@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
+    def test_open_player_with_title_vlc(self):
+        self._test_args(["streamlink", "-p", "/usr/bin/vlc", "--title", "{title}", "http://test.se", "test"],
+                        ["/usr/bin/vlc", "--input-title-format", 'Test Title', "-"])
+
+
+    def test_open_player_with_unicode_author_vlc(self):
+        self._test_args(["streamlink", "-p", "/usr/bin/vlc", "--title", "{author}", "http://test.se", "test"],
+                        ["/usr/bin/vlc", "--input-title-format", u"Tѥst Āuƭhǿr", "-"])
+
+
+    def test_open_player_with_default_title_vlc(self):
+        self._test_args(["streamlink", "-p", "/usr/bin/vlc", "http://test.se", "test"],
+                        ["/usr/bin/vlc", "--input-title-format", 'http://test.se', "-"])
+
+    def test_open_player_with_default_title_vlc_args(self):
+        self._test_args(["streamlink", "-p", "\"/Applications/VLC/vlc\" --other-option", "http://test.se", "test"],
+                        ["/Applications/VLC/vlc", "--other-option", "--input-title-format", 'http://test.se', "-"])
+
+
+@unittest.skipIf(not is_win32, "test only applicable on Windows")
+class TestCommandLineWithTitleWindows(CommandLineTestCase):
+    def test_open_player_with_title_vlc(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "--title", "{title}", "http://test.se", "test"],
+                        "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"Test Title\" -")
+
+    @unittest.skip("encoding unknown")
+    def test_open_player_with_unicode_author_vlc(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "--title", "{author}", "http://test.se", "test"],
+                        "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"T\xd1\xa5st \xc4\x80u\xc6\xadh\xc7\xbfr\" -")
+
+    def test_open_player_with_default_title_vlc(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe", "http://test.se", "test"],
+                        "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format http://test.se -")
+
+    def test_open_player_with_default_arg_vlc(self):
+        self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe --argh", "http://test.se", "test"],
+                        "c:\\Program Files\\VideoLAN\\vlc.exe --argh --input-title-format http://test.se -")

--- a/tests/test_lazy_formatter.py
+++ b/tests/test_lazy_formatter.py
@@ -1,6 +1,8 @@
 import unittest
+
 from mock import MagicMock
 from streamlink.utils import LazyFormatter
+
 
 class TestLazyFormat(unittest.TestCase):
     def _get_fake_plugin(self):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,57 @@
+import ntpath
+import posixpath
+import unittest
+
+from tests.mock import patch
+from streamlink_cli.output import PlayerOutput
+
+
+class TestPlayerOutput(unittest.TestCase):
+    def test_supported_player_generic(self):
+        self.assertEqual("vlc",
+                         PlayerOutput.supported_player("vlc"))
+
+        self.assertEqual("mpv",
+                         PlayerOutput.supported_player("mpv"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=ntpath.basename)
+    def test_supported_player_win32(self):
+        self.assertEqual("mpv",
+                         PlayerOutput.supported_player("C:\\MPV\\mpv.exe"))
+        self.assertEqual("vlc",
+                         PlayerOutput.supported_player("C:\\VLC\\vlc.exe"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
+    def test_supported_player_posix(self):
+        self.assertEqual("mpv",
+                         PlayerOutput.supported_player("/usr/bin/mpv"))
+        self.assertEqual("vlc",
+                         PlayerOutput.supported_player("/usr/bin/vlc"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=ntpath.basename)
+    def test_supported_player_args_win32(self):
+        self.assertEqual("mpv",
+                         PlayerOutput.supported_player("C:\\MPV\\mpv.exe --argh"))
+        self.assertEqual("vlc",
+                         PlayerOutput.supported_player("C:\\VLC\\vlc.exe --argh"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
+    def test_supported_player_args_posix(self):
+        self.assertEqual("mpv",
+                         PlayerOutput.supported_player("/usr/bin/mpv --argh"))
+        self.assertEqual("vlc",
+                         PlayerOutput.supported_player("/usr/bin/vlc --argh"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
+    def test_supported_player_negative_posix(self):
+        self.assertEqual(None,
+                         PlayerOutput.supported_player("/usr/bin/xmpvideo"))
+        self.assertEqual(None,
+                         PlayerOutput.supported_player("/usr/bin/echo"))
+
+    @patch("streamlink_cli.output.os.path.basename", new=ntpath.basename)
+    def test_supported_player_negative_win32(self):
+        self.assertEqual(None,
+                         PlayerOutput.supported_player("C:\\mpc\\mpc-hd.exe"))
+        self.assertEqual(None,
+                         PlayerOutput.supported_player("C:\\mplayer\\not-vlc.exe"))


### PR DESCRIPTION
Hey @Hubcapp, I think it's actually easier if I just open a PR to give you my fixes :) 

On Linux and macOS it doesn't look like you need to encode any unicode arguments - `subprocess` appears to handle it correctly. I tested with Python 2 and Python 3.

I have also improved the `supported_player` method so that it better detects the players and doesn't give false positives.

The only thing that needs more work is the `test_open_player_with_unicode_author_vlc` method in the Windows tests. I need to install Python 2 on my Windows box and test it there. I only tested on Windows with Python 3 - it works great though :) 